### PR TITLE
Updated Spring (Springboot 2.6.6 / Spring framework 5.3.18), because …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.8.RELEASE</version>
+		<version>2.6.6</version>
 		<relativePath />
 	</parent>
 
@@ -30,7 +30,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<spring-boot.version>2.3.8.RELEASE</spring-boot.version>
+		<spring-boot.version>2.6.6</spring-boot.version>
 		<java.version>1.8</java.version>
 		<log4j2.version>2.17.1</log4j2.version>
 	</properties>
@@ -112,6 +112,13 @@
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>5.8.2</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- JMS/ActiveMQ dependencies -->
 		<dependency>
 			<groupId>org.apache.activemq</groupId>
@@ -156,28 +163,6 @@
 			<version>2.4.1-3</version>
 		</dependency>
 	</dependencies>
-
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/libs-milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 
 	<build>
 		<!--
@@ -235,6 +220,7 @@
 					<execution>
 						<goals>
 							<goal>repackage</goal>
+							<goal>build-info</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -243,18 +229,6 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
-			</plugin>
-			
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>build-info</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
…of Spring vulnerability that might be a problem on next upgrade of java version.

Also fixed some other issues in pom:
 - fixed duplicated groupId+artifactId
 - removed repo.spring.io repository (https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020)